### PR TITLE
feat(skill, user): add skill management functionality

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,9 +7,10 @@ import { typeOrmConfig } from './config/typeorm.config';
 import { AuthModule } from './auth/auth.module';
 import { APP_INTERCEPTOR } from '@nestjs/core';
 import { ResponseInterceptor } from './common/interceptors/response.interceptor';
+import { SkillModule } from './skill/skill.module';
 
 @Module({
-  imports: [TypeOrmModule.forRoot(typeOrmConfig), UserModule, AuthModule],
+  imports: [TypeOrmModule.forRoot(typeOrmConfig), UserModule, AuthModule, SkillModule],
   controllers: [AppController],
   providers: [
     AppService,

--- a/src/migrations/1751889989068-skillsAndRelation.ts
+++ b/src/migrations/1751889989068-skillsAndRelation.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class SkillsAndRelation1751889989068 implements MigrationInterface {
+    name = 'SkillsAndRelation1751889989068'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "skill" ("id" SERIAL NOT NULL, "name" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "PK_a0d33334424e64fb78dc3ce7196" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE TABLE "user_skills_skill" ("userId" integer NOT NULL, "skillId" integer NOT NULL, CONSTRAINT "PK_972b9abaae51dbb33e482d81a26" PRIMARY KEY ("userId", "skillId"))`);
+        await queryRunner.query(`CREATE INDEX "IDX_b5cce6242aae7bce521a76a3be" ON "user_skills_skill" ("userId") `);
+        await queryRunner.query(`CREATE INDEX "IDX_c7e4f0b8d58a56f71dd097d754" ON "user_skills_skill" ("skillId") `);
+        await queryRunner.query(`ALTER TABLE "user_skills_skill" ADD CONSTRAINT "FK_b5cce6242aae7bce521a76a3be1" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE CASCADE`);
+        await queryRunner.query(`ALTER TABLE "user_skills_skill" ADD CONSTRAINT "FK_c7e4f0b8d58a56f71dd097d7546" FOREIGN KEY ("skillId") REFERENCES "skill"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "user_skills_skill" DROP CONSTRAINT "FK_c7e4f0b8d58a56f71dd097d7546"`);
+        await queryRunner.query(`ALTER TABLE "user_skills_skill" DROP CONSTRAINT "FK_b5cce6242aae7bce521a76a3be1"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_c7e4f0b8d58a56f71dd097d754"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_b5cce6242aae7bce521a76a3be"`);
+        await queryRunner.query(`DROP TABLE "user_skills_skill"`);
+        await queryRunner.query(`DROP TABLE "skill"`);
+    }
+
+}

--- a/src/skill/dto/create-skill.dto.ts
+++ b/src/skill/dto/create-skill.dto.ts
@@ -1,0 +1,1 @@
+export class CreateSkillDto {}

--- a/src/skill/dto/update-skill.dto.ts
+++ b/src/skill/dto/update-skill.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateSkillDto } from './create-skill.dto';
+
+export class UpdateSkillDto extends PartialType(CreateSkillDto) {}

--- a/src/skill/entities/skill.entity.ts
+++ b/src/skill/entities/skill.entity.ts
@@ -1,0 +1,16 @@
+import { User } from '../../user/entities/user.entity';
+import { Column, Entity, ManyToMany, PrimaryGeneratedColumn } from 'typeorm';
+@Entity()
+export class Skill {
+  @PrimaryGeneratedColumn()
+  id: number;
+  @Column()
+  name: string;
+  @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
+  createdAt: Date;
+  @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
+  updatedAt: Date;
+
+  @ManyToMany(() => User, (user) => user.skills)
+  users: User[];
+}

--- a/src/skill/skill.controller.ts
+++ b/src/skill/skill.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { SkillService } from './skill.service';
+import { CreateSkillDto } from './dto/create-skill.dto';
+import { UpdateSkillDto } from './dto/update-skill.dto';
+
+@Controller('skill')
+export class SkillController {
+  constructor(private readonly skillService: SkillService) {}
+
+  @Post()
+  create(@Body() createSkillDto: CreateSkillDto) {
+    return this.skillService.create(createSkillDto);
+  }
+
+  @Get()
+  findAll() {
+    return this.skillService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.skillService.findOne(+id);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() updateSkillDto: UpdateSkillDto) {
+    return this.skillService.update(+id, updateSkillDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.skillService.remove(+id);
+  }
+}

--- a/src/skill/skill.module.ts
+++ b/src/skill/skill.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { SkillService } from './skill.service';
+import { SkillController } from './skill.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Skill } from './entities/skill.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Skill])],
+  controllers: [SkillController],
+  providers: [SkillService],
+  exports: [TypeOrmModule],
+})
+export class SkillModule {}

--- a/src/skill/skill.service.ts
+++ b/src/skill/skill.service.ts
@@ -1,0 +1,34 @@
+import { InjectRepository } from '@nestjs/typeorm';
+import { Injectable } from '@nestjs/common';
+import { CreateSkillDto } from './dto/create-skill.dto';
+import { UpdateSkillDto } from './dto/update-skill.dto';
+import { Repository } from 'typeorm/repository/Repository';
+import { Skill } from './entities/skill.entity';
+
+@Injectable()
+export class SkillService {
+  constructor(
+    @InjectRepository(Skill)
+    private skillRepository: Repository<Skill>,
+  ) {}
+
+  create(createSkillDto: CreateSkillDto) {
+    const skill = this.skillRepository.create(createSkillDto);
+    return this.skillRepository.save(skill);
+  }
+  findAll() {
+    return this.skillRepository.find();
+  }
+
+  findOne(id: number) {
+    return this.skillRepository.find({ where: { id } });
+  }
+
+  update(id: number, updateSkillDto: UpdateSkillDto) {
+    return this.skillRepository.update(id, updateSkillDto);
+  }
+
+  remove(id: number) {
+    return this.skillRepository.delete(id);
+  }
+}

--- a/src/user/dto/add-skills.dto.ts
+++ b/src/user/dto/add-skills.dto.ts
@@ -1,0 +1,7 @@
+import { IsArray, IsString } from 'class-validator';
+
+export class AddSkillsDto {
+  @IsArray()
+  @IsString({ each: true })
+  skillNames: string[];
+}

--- a/src/user/entities/user.entity.ts
+++ b/src/user/entities/user.entity.ts
@@ -1,5 +1,12 @@
+import { Skill } from '../../skill/entities/skill.entity';
 import { Role } from '../../auth/enums/role.enum';
-import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToMany,
+  JoinTable,
+} from 'typeorm';
 @Entity()
 export class User {
   @PrimaryGeneratedColumn()
@@ -28,4 +35,8 @@ export class User {
 
   @Column({ type: 'timestamp', nullable: true })
   refreshTokenExpiresAt: Date;
+
+  @ManyToMany(() => Skill, (skill) => skill.users, { cascade: true })
+  @JoinTable()
+  skills: Skill[];
 }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -20,6 +20,7 @@ import { Roles } from '../auth/decorators/roles.decorator';
 import { Role } from '../auth/enums/role.enum';
 import { User } from '../auth/decorators/user.decorator';
 import { ResponseDto } from '../common/decorators/response.decorator';
+import { AddSkillsDto } from './dto/add-skills.dto';
 
 @Controller('user')
 export class UserController {
@@ -31,6 +32,13 @@ export class UserController {
   @Get()
   async findAll() {
     return this.userService.findAll();
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Patch('skills')
+  async addSkills(@User() currentUser: any, @Body() dto: AddSkillsDto) {
+    await this.userService.addSkillsToUser(currentUser.userId, dto.skillNames);
+    return { message: 'Skills added successfully' };
   }
 
   @UseGuards(JwtAuthGuard)

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -3,9 +3,10 @@ import { UserService } from './user.service';
 import { UserController } from './user.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from './entities/user.entity';
+import { SkillModule } from 'src/skill/skill.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User])],
+  imports: [TypeOrmModule.forFeature([User]), SkillModule],
   controllers: [UserController],
   providers: [UserService],
   exports: [UserService],


### PR DESCRIPTION
- Introduced Skill module with controller, service, and entity for managing skills.
- Implemented migration to create 'skill' and 'user_skills_skill' tables for skill relationships.
- Enhanced User module to support adding skills to users, including a new endpoint in UserController.
- Created DTOs for skill creation and updates, ensuring proper validation.
- Updated User entity to establish a many-to-many relationship with skills.